### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '18'
       - run: npm install -g yarn


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.3](https://github.com/actions/setup-node/releases/tag/v4.0.3)** on 2024-07-09T14:22:34Z
